### PR TITLE
Avoid token creation when not selected on checkout

### DIFF
--- a/assets/javascripts/front/main.js
+++ b/assets/javascripts/front/main.js
@@ -385,6 +385,13 @@ jQuery(function ($) {
     }
 
     const onSubmit = function (e) {
+
+        // Bail if payment method isn't Pagar.me
+        if( $( 'input[name=payment_method]:checked' ).val() !== 'woo-pagarme-payments' ) {
+            // Submit form normally
+            return submitForm();
+        }
+        
         const paymentMethod = $('input[name=pagarme_payment_method]:checked').get(0).value;
         if (hasCardId() && paymentMethod !== '2_cards') {
             return submitForm();


### PR DESCRIPTION
Because of this, if client chooses any payment method but pagar.me, checkout simply doesn't work.
No token can be created if pagar.me forms are empty. This commit address this issue.